### PR TITLE
Move the build process to Dockerfile, remove shared volumes for nodejs image

### DIFF
--- a/dev/Example_dashboard/Dockerfile
+++ b/dev/Example_dashboard/Dockerfile
@@ -9,6 +9,8 @@ USER node
 # Run the command inside your image filesystem.
 RUN npm install
 COPY --chown=node:node . .
+
+RUN ./node_modules/.bin/ng build
 # Add metadata to the image to describe which port the container is listening on at runtime.
 EXPOSE 3000
 # Run the specified command within the container.

--- a/dev/Example_dashboard/docker-compose.yml
+++ b/dev/Example_dashboard/docker-compose.yml
@@ -17,9 +17,6 @@ services:
       - MONGO_DB=$MONGO_DB
     ports:
       - "3000:3000"
-    volumes:
-      - .:/home/node/app
-      - node_modules:/home/node/app/node_modules
     networks:
       - app-network
     command: ./wait-for.sh db:27017 -- /home/node/app/node_modules/.bin/nodemon server.js
@@ -43,4 +40,3 @@ networks:
 
 volumes:
   dbdata:
-  node_modules:


### PR DESCRIPTION
## Docker issues & fixes
Due to the issues associated with not being able to run the docker-compose template, the volumes were removed. This includes related to permissions of accessing `node_modules/.staging/<...>`.

Additionally, this merge also fixes the caching issues that would result in re-running the same dockerimage template even after it has been updated.

## Front-end issues & fixes
Previously, the website had to be built prior to building docker image, as it was being copied during the docker image build process. Now, the angular build scripts are embedded in the docker image build process, which removes this prerequisite.


These fixes should make it easier to troubleshoot the build process (and allow to build to begin with) on systems that are running Docker Desktop or any other version of Docker that might be restricted in permissions, as well as non-linux systems where the directory structure does not necessarily represent that of linux one.